### PR TITLE
Fix dangling chip_name in sensors_get_detected_chips

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,14 +390,7 @@ impl Iterator for ChipIterator {
 	type Item = Chip;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		let chip_name_ptr: *const libsensors::sensors_chip_name =
-			if let Some(chip_name) = self.chip_name {
-				&chip_name
-			} else {
-				std::ptr::null_mut()
-			};
-
-		let ptr = unsafe { libsensors::sensors_get_detected_chips(chip_name_ptr, &mut self.index) };
+		let ptr = unsafe { libsensors::sensors_get_detected_chips(self.chip_name.as_ref().map_or(std::ptr::null(), |x| x), &mut self.index) };
 
 		if !ptr.is_null() {
 			unsafe { Some(Chip::from_ptr(ptr)) }


### PR DESCRIPTION
The previous code matched on the Option's *value*, which accidentally
worked because sensors_chip_name is Copy. It then created a dangling
reference, as the raw pointer conversion created an unbound lifetime.

Fix this by using as_ref with a shorter snippet for converting to raw
pointer.